### PR TITLE
fix a bug when save slice montage figure

### DIFF
--- a/bspmview.m
+++ b/bspmview.m
@@ -3902,7 +3902,7 @@ function uisavefig(defname, hfig)
 %     print(hfig, fmt, strcat('-', renderer), strcat('-', 'noui'), fullfile(pname,n));
 %     print(hfig, fmt, strcat('-', 'noui'), fullfile(pname,n));
 
-    print(hfig, fmt, fullfile(pname,n));
+    print(hfig, fmt, fullfile(pname,imname));
     fprintf('\nImage saved to %s\n', fullfile(pname, imname));
 function outmsg     = printmsg(msg, msgtitle, msgborder, msgwidth, hideoutput)
 % PRINTMSG Create and print a formatted message with title


### PR DESCRIPTION
Fix a bug when save slice montage figure to file, the file has no suffix, should use 'imname' to replace 'n' here.